### PR TITLE
Throw Error when glob is not a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function (glob, opts) {
-  if (glob == null) {
-    return null;
+  if (typeof glob !== 'string') {
+    throw new TypeError('Expected a string');
   }
 
   var str = String(glob);


### PR DESCRIPTION
Output like below is weird, both are edge cases where input is crap though.
I think that it makes more sense to throw an Error on invalid input type (like here: https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js#L6)

```js
var g = require('glob-to-regexp');

// Prints: /^\[object Object\]$/
g({});

// Prints: /^NaN$/
g(NaN);
```