### PR TITLE
Enhanced the globstar logic to support additional cases

### DIFF
--- a/test.js
+++ b/test.js
@@ -172,13 +172,27 @@ assertMatch("/foo/**", "/foo/bar/baz.txt", {globstar: true });
 assertMatch("/foo/*/*.txt", "/foo/bar/baz.txt", {globstar: true });
 assertMatch("/foo/**/*.txt", "/foo/bar/baz.txt", {globstar: true });
 assertMatch("/foo/**/*.txt", "/foo/bar/baz/qux.txt", {globstar: true });
+assertMatch("/foo/**/bar.txt", "/foo/bar.txt", {globstar: true });
+assertMatch("/foo/**/**/bar.txt", "/foo/bar.txt", {globstar: true });
+assertMatch("/foo/**/*/baz.txt", "/foo/bar/baz.txt", {globstar: true });
+assertMatch("/foo/**/*.txt", "/foo/bar.txt", {globstar: true });
+assertMatch("/foo/**/**/*.txt", "/foo/bar.txt", {globstar: true });
+assertMatch("/foo/**/*/*.txt", "/foo/bar/baz.txt", {globstar: true });
 assertMatch("**/*.txt", "/foo/bar/baz/qux.txt", {globstar: true });
+assertMatch("**/foo.txt", "foo.txt", {globstar: true });
+assertMatch("**/*.txt", "foo.txt", {globstar: true });
 
 assertNotMatch("/foo/*", "/foo/bar/baz.txt", {globstar: true });
 assertNotMatch("/foo/*.txt", "/foo/bar/baz.txt", {globstar: true });
 assertNotMatch("/foo/*/*.txt", "/foo/bar/baz/qux.txt", {globstar: true });
+assertNotMatch("/foo/*/bar.txt", "/foo/bar.txt", {globstar: true });
+assertNotMatch("/foo/*/*/baz.txt", "/foo/bar/baz.txt", {globstar: true });
+assertNotMatch("/foo/**.txt", "/foo/bar/baz/qux.txt", {globstar: true });
+assertNotMatch("/foo/bar**/*.txt", "/foo/bar/baz/qux.txt", {globstar: true });
+assertNotMatch("/foo/bar**", "/foo/bar/baz.txt", {globstar: true });
 assertNotMatch("**/.txt", "/foo/bar/baz/qux.txt", {globstar: true });
 assertNotMatch("*/*.txt", "/foo/bar/baz/qux.txt", {globstar: true });
+assertNotMatch("*/*.txt", "foo.txt", {globstar: true });
 
 assertNotMatch("http://foo.com/*",
                "http://foo.com/bar/baz/jquery.min.js",


### PR DESCRIPTION
The existing globstar logic didn't work for some valid glob patterns.  This PR fixes that, and also adds additional globstar tests.

These changes only take effect when the `globstar: true` option is set.  When not set, all functionality remains unchanged.