### PR TITLE
Fix: backslash does not need escaping 

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ module.exports = function (glob, opts) {
     c = str[i];
 
     switch (c) {
-    case "\\":
     case "/":
     case "$":
     case "^":

--- a/test.js
+++ b/test.js
@@ -47,9 +47,13 @@ function test(globstar) {
   assertMatch("*.min.js", "http://example.com/jquery.min.js", { flags: 'g' });
   assertMatch("*/js/*.js", "http://example.com/js/jquery.min.js", { flags: 'g' });
 
-  var testStr = "\\/$^+?.()=!|{},[].*"
-  assertMatch(testStr, testStr);
-  assertMatch(testStr, testStr, { flags: 'g' });
+  // Test string  "\\\\/$^+?.()=!|{},[].*"  represents  <glob>\\/$^+?.()=!|{},[].*</glob>
+  // The equivalent regex is:  /^\\\/\$\^\+\?\.\(\)\=\!\|\{\}\,\[\]\..*$/
+  // Both glob and regex match:  \/$^+?.()=!|{},[].*
+  var testStr = "\\\\/$^+?.()=!|{},[].*";
+  var targetStr = "\\/$^+?.()=!|{},[].*";
+  assertMatch(testStr, targetStr);
+  assertMatch(testStr, targetStr, { flags: 'g' });
 
   // Equivalent matches without/with using RegExp 'g'
   assertNotMatch(".min.", "http://example.com/jquery.min.js");
@@ -154,9 +158,13 @@ function test(globstar) {
               { extended: true,  globstar: globstar, flags: 'g' });
 
   // Remaining special chars should still match themselves
-  var testExtStr = "\\/$^+.()=!|,.*"
-  assertMatch(testExtStr, testExtStr, { extended: true });
-  assertMatch(testExtStr, testExtStr, { extended: true,  globstar: globstar, flags: 'g' });
+  // Test string  "\\\\/$^+.()=!|,.*"  represents  <glob>\\/$^+.()=!|,.*</glob>
+  // The equivalent regex is:  /^\\\/\$\^\+\.\(\)\=\!\|\,\..*$/
+  // Both glob and regex match:  \/$^+.()=!|,.*
+  var testExtStr = "\\\\/$^+.()=!|,.*";
+  var targetExtStr = "\\/$^+.()=!|,.*";
+  assertMatch(testExtStr, targetExtStr, { extended: true });
+  assertMatch(testExtStr, targetExtStr, { extended: true,  globstar: globstar, flags: 'g' });
 }
 
 // regression


### PR DESCRIPTION
Backslash ('\') does not need escaping as it is already escaped within the source glob pattern.

Example: 
The glob pattern <glob>a\\b</glob> (1) matches <text>a\b</text> (2).
The javascript string for glob (1) is "a\\\\b" (3).
Now, the RegEx equivalent to glob (1), which matches (2), is /a\\b/ (4).
The source for RegEx (4) is javascript string "a\\\\b" (5), which is equal to string (3).
Since string (3) is equal to string (5), this means string (3) can be used as-is to create RegEx (4). Consequently, glob-to-regexp should NOT prepend a backslash to any backslash character found in the glob argument during the conversion to regex process.