### PR TITLE
Add correct SPDX expression.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "wildcard"
   ],
   "author": "Nick Fitzgerald <fitzgen@gmail.com>",
-  "license": "BSD"
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
In the `package.json` file, so far the license was only specified as `BSD`, which is ambiguous. According to the `README.md` file, it seems to be `BSD-2-Clause`.

Hence I have updated the SPDX expression in the `package.json` file to be more specific.

Hope this helps 😊 